### PR TITLE
Do not use ApplicationRecord in migration

### DIFF
--- a/template/.rubocop/rails.yml
+++ b/template/.rubocop/rails.yml
@@ -21,6 +21,8 @@ Rails/ApplicationJob:
 
 Rails/ApplicationRecord:
   Enabled: true
+  Exclude:
+    - 'db/migrate/**/*'
 
 Rails/AssertNot:
   Enabled: true


### PR DESCRIPTION
Using ApplicationRecord in migrations can lead to unexpected behaviour when running migrations without a fully-configured Rails environment, and lead to unexpected behaviour from callbacks and other included logic.