### PR TITLE
chore: upgrade to standard 1.28

### DIFF
--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -4,9 +4,12 @@ inherit_mode:
 
 require:
   - standard
+  - rubocop-performance
 
 inherit_gem:
   standard: config/base.yml
+  standard-performance: config/base.yml
+  standard-custom: config/base.yml
 
 inherit_from:
 <% plugins.each do |plugin| %>

--- a/template/gemfiles/rubocop.gemfile
+++ b/template/gemfiles/rubocop.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org" do
   <% gems.each do |gem| %>
   gem "<%= gem %>"
   <% end %>
-  gem "standard", "~> 1.0"
+  gem "standard", "~> 1.28"
 end


### PR DESCRIPTION
`standard-performance` and `standard-custom` have been extracted into separate gems (and are loaded via [lint_roller](https://github.com/standardrb/lint_roller)). We need to specify their configs explicitly.

See https://github.com/standardrb/standard/pull/551